### PR TITLE
kafka 메시지 발행 및 Transactional Outbox Pattern 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     testImplementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker/kafka/docker-compose.yml
+++ b/docker/kafka/docker-compose.yml
@@ -18,3 +18,15 @@ services:
       KAFKA_CREATE_TOPICS: "ErJuer:1:1"  # Topic명:Partition개수:Replica개수
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      - kafka
+    ports:
+      - 8989:8080
+    environment:
+      - DYNAMIC_CONFIG_ENABLED=true
+      - KAFKA_CLUSTERS_0_NAME=local_kafka_cluster
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092

--- a/src/main/java/io/hhplus/reserve/common/kafka/KafkaConstant.java
+++ b/src/main/java/io/hhplus/reserve/common/kafka/KafkaConstant.java
@@ -1,0 +1,9 @@
+package io.hhplus.reserve.common.kafka;
+
+public class KafkaConstant {
+
+    public static final int MAX_RETRY_COUNT = 3;
+
+    public static final String PAYMENT_TOPIC = "payment-topic";
+
+}

--- a/src/main/java/io/hhplus/reserve/common/util/JsonUtil.java
+++ b/src/main/java/io/hhplus/reserve/common/util/JsonUtil.java
@@ -1,0 +1,99 @@
+package io.hhplus.reserve.common.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import lombok.NoArgsConstructor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor
+public class JsonUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * JSON String to Object
+     */
+    public static <T> T jsonStringToObject(String jsonString, Class<T> clazz) {
+        T object;
+        try {
+            object = objectMapper.readValue(jsonString, clazz);
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        return object;
+    }
+
+    /**
+     * Object to JSON String
+     */
+    public static <T> String objectToJsonString(T object) {
+        String jsonString;
+        try {
+            jsonString = objectMapper.writeValueAsString(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return jsonString;
+    }
+
+    /**
+     * Map to JSON String
+     */
+    public static String mapToJsonString(Map<String, Object> map) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(map);
+    }
+
+    /**
+     * List<Map> to JSON String
+     */
+    public static String listOfMapToJsonString(List<Map<String, Object>> list)
+            throws JsonProcessingException {
+        return objectMapper.writeValueAsString(list);
+    }
+
+    /**
+     * JSON String to Map
+     */
+    public static Map<String, Object> jsonStringToMap(String jsonString) throws IOException {
+        return objectMapper.readValue(jsonString, new TypeReference<Map<String, Object>>() {});
+    }
+
+    /**
+     * JSON String to List
+     */
+    public static <T> List<T> jsonStringToList(String jsonString, Class<T> clazz) throws IOException {
+        return objectMapper.readValue(
+                jsonString,
+                objectMapper.getTypeFactory().constructCollectionType(List.class, clazz)
+        );
+    }
+
+    /**
+     * JSON Object to Map<String, String>
+     */
+    public static Map<String, String> jsonObjectToMap(Map<String, Object> jsonObject) {
+        return jsonObject.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey, entry -> entry.getValue().toString()
+                ));
+    }
+
+    /**
+     * JSON Array to List<Map<String, String>>
+     */
+    public static List<Map<String, String>> jsonArrayToListOfMap(String jsonArrayString) throws IOException {
+        return objectMapper.readValue(
+                jsonArrayString,
+                TypeFactory.defaultInstance().constructCollectionType(
+                        List.class,
+                        TypeFactory.defaultInstance().constructMapType(Map.class, String.class, String.class)
+                )
+        );
+    }
+}

--- a/src/main/java/io/hhplus/reserve/external/application/ExternalService.java
+++ b/src/main/java/io/hhplus/reserve/external/application/ExternalService.java
@@ -1,6 +1,5 @@
 package io.hhplus.reserve.external.application;
 
-import io.hhplus.reserve.payment.domain.PaymentInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -8,8 +7,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ExternalService {
 
-    public void notifyPaymentSuccess(PaymentInfo.Main info) {
-        log.info("notifyPaymentSuccess::: {}", info);
+    public void notifyPaymentSuccess(Long paymentId) {
+        log.info("# [ExternalService] notifyPaymentSuccess::: paymentId: {}", paymentId);
     }
-
 }

--- a/src/main/java/io/hhplus/reserve/outbox/application/OutboxFacade.java
+++ b/src/main/java/io/hhplus/reserve/outbox/application/OutboxFacade.java
@@ -1,0 +1,36 @@
+package io.hhplus.reserve.outbox.application;
+
+import io.hhplus.reserve.common.annotation.Facade;
+import io.hhplus.reserve.common.kafka.KafkaConstant;
+import io.hhplus.reserve.outbox.domain.Outbox;
+import io.hhplus.reserve.outbox.domain.OutboxService;
+import io.hhplus.reserve.payment.infra.event.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+@Slf4j
+@Facade
+@RequiredArgsConstructor
+public class OutboxFacade {
+
+    private final OutboxService outboxService;
+    private final KafkaProducer kafkaProducer;
+
+    public void retrySendOutboxMessage() {
+        List<Outbox> outboxList = outboxService.getNotPublishedOutboxList();
+        for (Outbox outbox : outboxList) {
+            if (outbox.getCount() >= KafkaConstant.MAX_RETRY_COUNT) {
+                outbox.unpublished();
+                outboxService.saveOutbox(outbox);
+                continue;
+            }
+
+            kafkaProducer.send(outbox.getTopic(), outbox.getId(), outbox.getMessage());
+            outbox.increaseCount();
+            outboxService.saveOutbox(outbox);
+        }
+    }
+
+}

--- a/src/main/java/io/hhplus/reserve/outbox/application/OutboxFacade.java
+++ b/src/main/java/io/hhplus/reserve/outbox/application/OutboxFacade.java
@@ -1,7 +1,6 @@
 package io.hhplus.reserve.outbox.application;
 
 import io.hhplus.reserve.common.annotation.Facade;
-import io.hhplus.reserve.common.kafka.KafkaConstant;
 import io.hhplus.reserve.outbox.domain.Outbox;
 import io.hhplus.reserve.outbox.domain.OutboxService;
 import io.hhplus.reserve.payment.infra.event.KafkaProducer;
@@ -21,16 +20,8 @@ public class OutboxFacade {
     public void retrySendOutboxMessage() {
         List<Outbox> outboxList = outboxService.getNotPublishedOutboxList();
         for (Outbox outbox : outboxList) {
-            if (outbox.getCount() >= KafkaConstant.MAX_RETRY_COUNT) {
-                outbox.unpublished();
-                outboxService.saveOutbox(outbox);
-                continue;
-            }
-
+            outboxService.increaseOutboxCount(outbox);
             kafkaProducer.send(outbox.getTopic(), outbox.getId(), outbox.getMessage());
-            outbox.increaseCount();
-            outboxService.saveOutbox(outbox);
         }
     }
-
 }

--- a/src/main/java/io/hhplus/reserve/outbox/application/OutboxFacade.java
+++ b/src/main/java/io/hhplus/reserve/outbox/application/OutboxFacade.java
@@ -1,6 +1,7 @@
 package io.hhplus.reserve.outbox.application;
 
 import io.hhplus.reserve.common.annotation.Facade;
+import io.hhplus.reserve.common.util.JsonUtil;
 import io.hhplus.reserve.outbox.domain.Outbox;
 import io.hhplus.reserve.outbox.domain.OutboxService;
 import io.hhplus.reserve.payment.infra.event.KafkaProducer;
@@ -21,7 +22,8 @@ public class OutboxFacade {
         List<Outbox> outboxList = outboxService.getNotPublishedOutboxList();
         for (Outbox outbox : outboxList) {
             outboxService.increaseOutboxCount(outbox);
-            kafkaProducer.send(outbox.getTopic(), outbox.getId(), outbox.getMessage());
+            Long paymentId = JsonUtil.jsonStringToObject(outbox.getMessage(), Long.class);
+            kafkaProducer.send(outbox.getTopic(), outbox.getId(), paymentId);
         }
     }
 }

--- a/src/main/java/io/hhplus/reserve/outbox/domain/Outbox.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/Outbox.java
@@ -1,0 +1,69 @@
+package io.hhplus.reserve.outbox.domain;
+
+import io.hhplus.reserve.support.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "outbox")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Outbox extends BaseEntity {
+
+    @Id
+    @Column(name = "id")
+    private String id;
+
+    @Column(name = "domain_name")
+    private String domainName;
+
+    @Column(name = "topic", columnDefinition = "longtext")
+    private String topic;
+
+    @Column(name = "event_type")
+    private String eventType;
+
+    @Column(name = "message")
+    private String message;
+
+    @Builder.Default
+    @Column(name = "is_published", columnDefinition = "tinyint")
+    private boolean isPublished = false;
+
+    @Column(name = "count")
+    private int count;
+
+    public static Outbox create(String domainName, String topic, String eventType, String message) {
+        return Outbox.builder()
+                .id(UUID.randomUUID().toString())
+                .domainName(domainName)
+                .topic(topic)
+                .eventType(eventType)
+                .message(message)
+                .count(0)
+                .build();
+    }
+
+    public void published() {
+        this.isPublished = true;
+    }
+
+    public void unpublished() {
+        this.isPublished = false;
+    }
+
+    public void increaseCount() {
+        this.count++;
+    }
+
+}

--- a/src/main/java/io/hhplus/reserve/outbox/domain/Outbox.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/Outbox.java
@@ -10,8 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.UUID;
-
 @Entity
 @Table(name = "outbox")
 @Getter
@@ -43,9 +41,9 @@ public class Outbox extends BaseEntity {
     @Column(name = "count")
     private int count;
 
-    public static Outbox create(String domainName, String topic, String eventType, String message) {
+    public static Outbox create(String id, String domainName, String topic, String eventType, String message) {
         return Outbox.builder()
-                .id(UUID.randomUUID().toString())
+                .id(id)
                 .domainName(domainName)
                 .topic(topic)
                 .eventType(eventType)

--- a/src/main/java/io/hhplus/reserve/outbox/domain/OutboxRepository.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/OutboxRepository.java
@@ -1,8 +1,12 @@
 package io.hhplus.reserve.outbox.domain;
 
+import java.util.List;
+
 public interface OutboxRepository {
 
     Outbox save(Outbox outbox);
 
     Outbox findById(String id);
+
+    List<Outbox> findAllByIsPublished(boolean isPublished);
 }

--- a/src/main/java/io/hhplus/reserve/outbox/domain/OutboxRepository.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/OutboxRepository.java
@@ -1,0 +1,8 @@
+package io.hhplus.reserve.outbox.domain;
+
+public interface OutboxRepository {
+
+    Outbox save(Outbox outbox);
+
+    Outbox findById(String id);
+}

--- a/src/main/java/io/hhplus/reserve/outbox/domain/OutboxService.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/OutboxService.java
@@ -3,6 +3,8 @@ package io.hhplus.reserve.outbox.domain;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class OutboxService {
@@ -15,5 +17,9 @@ public class OutboxService {
 
     public Outbox getOutboxById(String id) {
         return outboxRepository.findById(id);
+    }
+
+    public List<Outbox> getNotPublishedOutboxList() {
+        return outboxRepository.findAllByIsPublished(false);
     }
 }

--- a/src/main/java/io/hhplus/reserve/outbox/domain/OutboxService.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/OutboxService.java
@@ -2,6 +2,7 @@ package io.hhplus.reserve.outbox.domain;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,8 +16,17 @@ public class OutboxService {
         outboxRepository.save(outbox);
     }
 
-    public Outbox getOutboxById(String id) {
-        return outboxRepository.findById(id);
+    @Transactional
+    public void publishOutbox(String id) {
+        Outbox outbox = outboxRepository.findById(id);
+        outbox.published();
+        outboxRepository.save(outbox);
+    }
+
+    @Transactional
+    public void increaseOutboxCount(Outbox outbox) {
+        outbox.increaseCount();
+        outboxRepository.save(outbox);
     }
 
     public List<Outbox> getNotPublishedOutboxList() {

--- a/src/main/java/io/hhplus/reserve/outbox/domain/OutboxService.java
+++ b/src/main/java/io/hhplus/reserve/outbox/domain/OutboxService.java
@@ -1,0 +1,19 @@
+package io.hhplus.reserve.outbox.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+    private final OutboxRepository outboxRepository;
+
+    public void saveOutbox(Outbox outbox) {
+        outboxRepository.save(outbox);
+    }
+
+    public Outbox getOutboxById(String id) {
+        return outboxRepository.findById(id);
+    }
+}

--- a/src/main/java/io/hhplus/reserve/outbox/infra/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/reserve/outbox/infra/OutboxJpaRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Repository
 public interface OutboxJpaRepository extends JpaRepository<Outbox, String> {
 
-    @Query("select o from Outbox o where o.isPublished = :isPublished")
-    List<Outbox> findAllByPublished(@Param("isPublished") boolean isPublished);
+    @Query("select o from Outbox o where o.isPublished = :isPublished and o.count <= :count")
+    List<Outbox> findAllByPublished(@Param("isPublished") boolean isPublished, @Param("count") int count);
 }

--- a/src/main/java/io/hhplus/reserve/outbox/infra/OutboxJpaRepository.java
+++ b/src/main/java/io/hhplus/reserve/outbox/infra/OutboxJpaRepository.java
@@ -1,0 +1,16 @@
+package io.hhplus.reserve.outbox.infra;
+
+import io.hhplus.reserve.outbox.domain.Outbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OutboxJpaRepository extends JpaRepository<Outbox, String> {
+
+    @Query("select o from Outbox o where o.isPublished = :isPublished")
+    List<Outbox> findAllByPublished(@Param("isPublished") boolean isPublished);
+}

--- a/src/main/java/io/hhplus/reserve/outbox/infra/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/reserve/outbox/infra/OutboxRepositoryImpl.java
@@ -23,4 +23,9 @@ public class OutboxRepositoryImpl implements OutboxRepository {
     public Outbox findById(String id) {
         return outboxJpaRepository.findById(id).orElseThrow(EntityNotFoundException::new);
     }
+
+    @Override
+    public List<Outbox> findAllByIsPublished(boolean isPublished) {
+        return outboxJpaRepository.findAllByPublished(isPublished);
+    }
 }

--- a/src/main/java/io/hhplus/reserve/outbox/infra/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/reserve/outbox/infra/OutboxRepositoryImpl.java
@@ -1,0 +1,26 @@
+package io.hhplus.reserve.outbox.infra;
+
+import io.hhplus.reserve.outbox.domain.Outbox;
+import io.hhplus.reserve.outbox.domain.OutboxRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public Outbox save(Outbox outbox) {
+        return outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public Outbox findById(String id) {
+        return outboxJpaRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+    }
+}

--- a/src/main/java/io/hhplus/reserve/outbox/infra/OutboxRepositoryImpl.java
+++ b/src/main/java/io/hhplus/reserve/outbox/infra/OutboxRepositoryImpl.java
@@ -1,5 +1,6 @@
 package io.hhplus.reserve.outbox.infra;
 
+import io.hhplus.reserve.common.kafka.KafkaConstant;
 import io.hhplus.reserve.outbox.domain.Outbox;
 import io.hhplus.reserve.outbox.domain.OutboxRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -26,6 +27,6 @@ public class OutboxRepositoryImpl implements OutboxRepository {
 
     @Override
     public List<Outbox> findAllByIsPublished(boolean isPublished) {
-        return outboxJpaRepository.findAllByPublished(isPublished);
+        return outboxJpaRepository.findAllByPublished(isPublished, KafkaConstant.MAX_RETRY_COUNT);
     }
 }

--- a/src/main/java/io/hhplus/reserve/outbox/scheduler/OutboxScheduler.java
+++ b/src/main/java/io/hhplus/reserve/outbox/scheduler/OutboxScheduler.java
@@ -1,0 +1,23 @@
+package io.hhplus.reserve.outbox.scheduler;
+
+import io.hhplus.reserve.outbox.application.OutboxFacade;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxScheduler {
+
+    private final OutboxFacade outboxFacade;
+
+    // 재시도 (5s)
+    @Scheduled(fixedRate = 5000)
+    public void retrySendOutboxMessage() {
+        log.info("# [OutboxScheduler] ::: Scheduler Start");
+        outboxFacade.retrySendOutboxMessage();
+        log.info("# [OutboxScheduler] ::: Scheduler End");
+    }
+}

--- a/src/main/java/io/hhplus/reserve/outbox/scheduler/OutboxScheduler.java
+++ b/src/main/java/io/hhplus/reserve/outbox/scheduler/OutboxScheduler.java
@@ -13,8 +13,8 @@ public class OutboxScheduler {
 
     private final OutboxFacade outboxFacade;
 
-    // 재시도 (5s)
-    @Scheduled(fixedRate = 5000)
+    // 재시도 (5 min)
+    @Scheduled(fixedRate = 300000)
     public void retrySendOutboxMessage() {
         log.info("# [OutboxScheduler] ::: Scheduler Start");
         outboxFacade.retrySendOutboxMessage();

--- a/src/main/java/io/hhplus/reserve/payment/application/PaymentFacade.java
+++ b/src/main/java/io/hhplus/reserve/payment/application/PaymentFacade.java
@@ -60,7 +60,7 @@ public class PaymentFacade {
         concertService.confirmSeat(seatList);
 
         // 결제 성공 이벤트
-        PaymentSuccessEvent successEvent = new PaymentSuccessEvent(payment, reservation, command.getToken());
+        PaymentSuccessEvent successEvent = PaymentSuccessEvent.create(payment, reservation, command.getToken());
         paymentEventPublisher.success(successEvent);
 
         return PaymentInfo.Main.of(payment, reservation);

--- a/src/main/java/io/hhplus/reserve/payment/application/PaymentFacade.java
+++ b/src/main/java/io/hhplus/reserve/payment/application/PaymentFacade.java
@@ -60,7 +60,7 @@ public class PaymentFacade {
         concertService.confirmSeat(seatList);
 
         // 결제 성공 이벤트
-        PaymentSuccessEvent successEvent = PaymentSuccessEvent.create(payment, reservation, command.getToken());
+        PaymentSuccessEvent successEvent = PaymentSuccessEvent.create(payment.getPaymentId(), command.getToken());
         paymentEventPublisher.success(successEvent);
 
         return PaymentInfo.Main.of(payment, reservation);

--- a/src/main/java/io/hhplus/reserve/payment/domain/PaymentInfo.java
+++ b/src/main/java/io/hhplus/reserve/payment/domain/PaymentInfo.java
@@ -6,14 +6,21 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class PaymentInfo {
+public class PaymentInfo implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Getter
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Main {
+    public static class Main implements Serializable {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
         private Long reservationId;
         private Long paymentId;
         private Long userId;

--- a/src/main/java/io/hhplus/reserve/payment/domain/event/PaymentSuccessEvent.java
+++ b/src/main/java/io/hhplus/reserve/payment/domain/event/PaymentSuccessEvent.java
@@ -1,26 +1,25 @@
 package io.hhplus.reserve.payment.domain.event;
 
-import io.hhplus.reserve.payment.domain.Payment;
-import io.hhplus.reserve.payment.domain.PaymentInfo;
-import io.hhplus.reserve.reservation.domain.Reservation;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.UUID;
 
 @Getter
-public class PaymentSuccessEvent {
+@NoArgsConstructor
+@AllArgsConstructor
+public final class PaymentSuccessEvent implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
 
-    private final PaymentInfo.Main info;
-    private final String token;
-    private final String outboxId;
+    private Long paymentId;
+    private String token;
+    private String outboxId;
 
-    public PaymentSuccessEvent(Payment payment, Reservation reservation, String token, String outboxId) {
-        this.info = PaymentInfo.Main.of(payment, reservation);
-        this.token = token;
-        this.outboxId = outboxId;
-    }
-
-    public static PaymentSuccessEvent create(Payment payment, Reservation reservation, String token) {
-        return new PaymentSuccessEvent(payment, reservation, token, UUID.randomUUID().toString());
+    public static PaymentSuccessEvent create(Long paymentId, String token) {
+        return new PaymentSuccessEvent(paymentId, token, UUID.randomUUID().toString());
     }
 }

--- a/src/main/java/io/hhplus/reserve/payment/domain/event/PaymentSuccessEvent.java
+++ b/src/main/java/io/hhplus/reserve/payment/domain/event/PaymentSuccessEvent.java
@@ -5,14 +5,22 @@ import io.hhplus.reserve.payment.domain.PaymentInfo;
 import io.hhplus.reserve.reservation.domain.Reservation;
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Getter
 public class PaymentSuccessEvent {
 
     private final PaymentInfo.Main info;
     private final String token;
+    private final String outboxId;
 
-    public PaymentSuccessEvent(Payment payment, Reservation reservation, String token) {
+    public PaymentSuccessEvent(Payment payment, Reservation reservation, String token, String outboxId) {
         this.info = PaymentInfo.Main.of(payment, reservation);
         this.token = token;
+        this.outboxId = outboxId;
+    }
+
+    public static PaymentSuccessEvent create(Payment payment, Reservation reservation, String token) {
+        return new PaymentSuccessEvent(payment, reservation, token, UUID.randomUUID().toString());
     }
 }

--- a/src/main/java/io/hhplus/reserve/payment/infra/event/KafkaProducer.java
+++ b/src/main/java/io/hhplus/reserve/payment/infra/event/KafkaProducer.java
@@ -1,0 +1,28 @@
+package io.hhplus.reserve.payment.infra.event;
+
+import io.hhplus.reserve.common.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void send(String topic, String id, Object payload) {
+        kafkaTemplate.send(topic, id, JsonUtil.objectToJsonString(payload)).whenComplete((result, exception) -> {
+            if (exception == null) {
+                RecordMetadata metadata = result.getRecordMetadata();
+                log.info("# [KafkaProducer] ::: topic: {}, value: {}, offset: {}", metadata.topic(), result.getProducerRecord().value(), metadata.offset());
+            } else {
+                log.error("# [KafkaProducer] ::: {}", exception.getMessage());
+                throw new RuntimeException("Kafka Producer Send Message Fail", exception);
+            }
+        });
+    }
+}

--- a/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventConsumer.java
+++ b/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventConsumer.java
@@ -3,9 +3,7 @@ package io.hhplus.reserve.payment.interfaces.event;
 import io.hhplus.reserve.common.kafka.KafkaConstant;
 import io.hhplus.reserve.common.util.JsonUtil;
 import io.hhplus.reserve.external.application.ExternalService;
-import io.hhplus.reserve.outbox.domain.Outbox;
 import io.hhplus.reserve.outbox.domain.OutboxService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -20,13 +18,10 @@ public class PaymentEventConsumer {
     private final OutboxService outboxService;
     private final ExternalService externalService;
 
-    @Transactional
     @KafkaListener(topics = KafkaConstant.PAYMENT_TOPIC, groupId = "payment-outbox")
     public void outboxPublished(ConsumerRecord<String, String> consumerRecord){
         log.info("# [PaymentEventConsumer] outboxPublished ::: {}", consumerRecord.key());
-        Outbox outbox = outboxService.getOutboxById(consumerRecord.key());
-        outbox.published();
-        outboxService.saveOutbox(outbox);
+        outboxService.publishOutbox(consumerRecord.key());
     }
 
     @KafkaListener(topics = KafkaConstant.PAYMENT_TOPIC, groupId = "payment-notify")

--- a/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventConsumer.java
+++ b/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventConsumer.java
@@ -5,7 +5,7 @@ import io.hhplus.reserve.common.util.JsonUtil;
 import io.hhplus.reserve.external.application.ExternalService;
 import io.hhplus.reserve.outbox.domain.Outbox;
 import io.hhplus.reserve.outbox.domain.OutboxService;
-import io.hhplus.reserve.payment.domain.PaymentInfo;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -20,6 +20,7 @@ public class PaymentEventConsumer {
     private final OutboxService outboxService;
     private final ExternalService externalService;
 
+    @Transactional
     @KafkaListener(topics = KafkaConstant.PAYMENT_TOPIC, groupId = "payment-outbox")
     public void outboxPublished(ConsumerRecord<String, String> consumerRecord){
         log.info("# [PaymentEventConsumer] outboxPublished ::: {}", consumerRecord.key());
@@ -31,7 +32,7 @@ public class PaymentEventConsumer {
     @KafkaListener(topics = KafkaConstant.PAYMENT_TOPIC, groupId = "payment-notify")
     public void successPayment(ConsumerRecord<String, String> consumerRecord){
         log.info("# [PaymentEventConsumer] successPayment ::: {}", consumerRecord.value());
-        PaymentInfo.Main info = JsonUtil.jsonStringToObject(consumerRecord.value(), PaymentInfo.Main.class);
-        externalService.notifyPaymentSuccess(info);
+        Long paymentId = JsonUtil.jsonStringToObject(consumerRecord.value(), Long.class);
+        externalService.notifyPaymentSuccess(paymentId);
     }
 }

--- a/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventConsumer.java
+++ b/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventConsumer.java
@@ -1,0 +1,37 @@
+package io.hhplus.reserve.payment.interfaces.event;
+
+import io.hhplus.reserve.common.kafka.KafkaConstant;
+import io.hhplus.reserve.common.util.JsonUtil;
+import io.hhplus.reserve.external.application.ExternalService;
+import io.hhplus.reserve.outbox.domain.Outbox;
+import io.hhplus.reserve.outbox.domain.OutboxService;
+import io.hhplus.reserve.payment.domain.PaymentInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentEventConsumer {
+
+    private final OutboxService outboxService;
+    private final ExternalService externalService;
+
+    @KafkaListener(topics = KafkaConstant.PAYMENT_TOPIC, groupId = "payment-outbox")
+    public void outboxPublished(ConsumerRecord<String, String> consumerRecord){
+        log.info("# [PaymentEventConsumer] outboxPublished ::: {}", consumerRecord.key());
+        Outbox outbox = outboxService.getOutboxById(consumerRecord.key());
+        outbox.published();
+        outboxService.saveOutbox(outbox);
+    }
+
+    @KafkaListener(topics = KafkaConstant.PAYMENT_TOPIC, groupId = "payment-notify")
+    public void successPayment(ConsumerRecord<String, String> consumerRecord){
+        log.info("# [PaymentEventConsumer] successPayment ::: {}", consumerRecord.value());
+        PaymentInfo.Main info = JsonUtil.jsonStringToObject(consumerRecord.value(), PaymentInfo.Main.class);
+        externalService.notifyPaymentSuccess(info);
+    }
+}

--- a/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventListener.java
+++ b/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventListener.java
@@ -28,7 +28,7 @@ public class PaymentEventListener {
                 "PAYMENT",
                 KafkaConstant.PAYMENT_TOPIC,
                 "PaymentSuccessEvent",
-                JsonUtil.objectToJsonString(event)
+                JsonUtil.objectToJsonString(event.getPaymentId())
         );
         outboxService.saveOutbox(outbox);
     }

--- a/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventListener.java
+++ b/src/main/java/io/hhplus/reserve/payment/interfaces/event/PaymentEventListener.java
@@ -24,6 +24,7 @@ public class PaymentEventListener {
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void createOutbox(PaymentSuccessEvent event) {
         Outbox outbox = Outbox.create(
+                event.getOutboxId(),
                 "PAYMENT",
                 KafkaConstant.PAYMENT_TOPIC,
                 "PaymentSuccessEvent",
@@ -38,7 +39,7 @@ public class PaymentEventListener {
         kafkaProducer.send(
                 KafkaConstant.PAYMENT_TOPIC,
                 event.getOutboxId(),
-                event.getInfo()
+                event.getPaymentId()
         );
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/reserve_db
+    url: jdbc:mysql://localhost:3307/reserve_db
     username: hhplus
     password: hhplus
     hikari:
@@ -24,6 +24,10 @@ spring:
     generate-ddl: true
     open-in-view: false
     show-sql: true
+
+  docker:
+    compose:
+      enabled: false
 
   data:
     redis:

--- a/src/test/java/io/hhplus/reserve/payment/application/PaymentFacadeEventTest.java
+++ b/src/test/java/io/hhplus/reserve/payment/application/PaymentFacadeEventTest.java
@@ -1,0 +1,75 @@
+package io.hhplus.reserve.payment.application;
+
+import io.hhplus.reserve.common.kafka.KafkaConstant;
+import io.hhplus.reserve.common.util.JsonUtil;
+import io.hhplus.reserve.config.TestContainerSupport;
+import io.hhplus.reserve.outbox.domain.Outbox;
+import io.hhplus.reserve.outbox.domain.OutboxRepository;
+import io.hhplus.reserve.payment.domain.event.PaymentSuccessEvent;
+import io.hhplus.reserve.payment.infra.event.KafkaProducer;
+import io.hhplus.reserve.waiting.domain.WaitingRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Slf4j
+class PaymentFacadeEventTest extends TestContainerSupport {
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Autowired
+    private OutboxRepository outboxRepository;
+
+    @Autowired
+    private KafkaProducer kafkaProducer;
+
+    @Test
+    void testJsonSerialization() {
+        PaymentSuccessEvent event = new PaymentSuccessEvent(1L, "token123", "outbox123");
+        String json = JsonUtil.objectToJsonString(event);
+        assertThat(json).isNotEmpty();
+
+        PaymentSuccessEvent deserializedEvent = JsonUtil.jsonStringToObject(json, PaymentSuccessEvent.class);
+        assertThat(deserializedEvent.getPaymentId()).isEqualTo(1L);
+        assertThat(deserializedEvent.getToken()).isEqualTo("token123");
+    }
+
+    @Test
+    @DisplayName("결제 성공 메시지 발행 테스트")
+    void consumeTest() {
+        String token = UUID.randomUUID().toString();
+
+        PaymentSuccessEvent event = PaymentSuccessEvent.create(1L, token);
+
+        Outbox outbox = Outbox.create(
+                event.getOutboxId(),
+                "PAYMENT",
+                KafkaConstant.PAYMENT_TOPIC,
+                "PaymentSuccessEvent",
+                JsonUtil.objectToJsonString(event)
+        );
+        outboxRepository.save(outbox);
+
+        kafkaProducer.send(
+                KafkaConstant.PAYMENT_TOPIC,
+                event.getOutboxId(),
+                event.getPaymentId()
+        );
+
+        // then
+        await().pollDelay(2, TimeUnit.SECONDS)
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    Outbox updatedOutbox = outboxRepository.findById(event.getOutboxId());
+                    assertThat(updatedOutbox.isPublished()).isEqualTo(true);
+                });
+    }
+}

--- a/src/test/java/io/hhplus/reserve/payment/application/PaymentFacadeEventTest.java
+++ b/src/test/java/io/hhplus/reserve/payment/application/PaymentFacadeEventTest.java
@@ -50,7 +50,7 @@ class PaymentFacadeEventTest extends TestContainerSupport {
                 "PAYMENT",
                 KafkaConstant.PAYMENT_TOPIC,
                 "PaymentSuccessEvent",
-                JsonUtil.objectToJsonString(event)
+                JsonUtil.objectToJsonString(event.getPaymentId())
         );
         outboxRepository.save(outbox);
 

--- a/src/test/java/io/hhplus/reserve/payment/application/PaymentFacadeEventTest.java
+++ b/src/test/java/io/hhplus/reserve/payment/application/PaymentFacadeEventTest.java
@@ -7,7 +7,6 @@ import io.hhplus.reserve.outbox.domain.Outbox;
 import io.hhplus.reserve.outbox.domain.OutboxRepository;
 import io.hhplus.reserve.payment.domain.event.PaymentSuccessEvent;
 import io.hhplus.reserve.payment.infra.event.KafkaProducer;
-import io.hhplus.reserve.waiting.domain.WaitingRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,9 +20,6 @@ import static org.awaitility.Awaitility.await;
 
 @Slf4j
 class PaymentFacadeEventTest extends TestContainerSupport {
-
-    @Autowired
-    private WaitingRepository waitingRepository;
 
     @Autowired
     private OutboxRepository outboxRepository;


### PR DESCRIPTION
### 작업 내용
- 기존 spring event kafka 대체
- Transactional Outbox Pattern 적용
- 실패한 트랜잭션 재처리 스케줄러 추가

### 리뷰 포인트
- 현재는 공통된 `outbox` 테이블에 `is_published` 컬럼이 존재해서 이벤트 발행 성공 시 `success` 상태로 update 해주고있습니다.
그런데 예시를 찾아보니 해당 테이블에선 insert 만 진행한다는 예시를 보았는데 실제로도 그렇게 하시는 편일까요?
- `outbox` 테이블에 `domain_name`을 두는 것보다 도메인마다 `${domain_name}_outbox` 테이블을 따로 생성하는게 맞을까요?
- outbox 발행 실패 케이스에 대해 재발행을 하는 `OutboxScheduler` 를 작성했습니다. 스케줄러 작동 텀을 현재는 5초로 설정했는데, 설정하고 보니 실제 이벤트가 구동되는 사이 텀에 스케줄링이 실행된다면 중복발행이 되지않을까 하는 생각이 들었습니다.. 단순히 스케줄러 동작 시간을 늘리는 것으로 궁극적인 해결이 되지는 않을 것 같은데 어떤 식으로 해결할 수 있을까요..? `outbox` 에서 `is_published` 필드를 두는 것보다 `status` 필드로 변경해서 ( INIT, PUBLISHED, FAIL ) 로 두고 스케줄러에서 fail 상태인 목록만 불러오도록 한다면 좀 더 명확해질까요...?